### PR TITLE
Minor typos/grammar

### DIFF
--- a/avro-serialization/README.md
+++ b/avro-serialization/README.md
@@ -16,7 +16,7 @@ Tis is done by the avro maven plugin and can be achieved running:
 
 ```$ mvn clean package -DskipTests```
 
-Zookeeper, Kafka nad the Schema Registry have to be running:
+Zookeeper, Kafka and the Schema Registry have to be running:
 
 ```
 $ ./bin/zookeeper-server-start ./etc/kafka/zookeeper.properties &
@@ -29,18 +29,18 @@ $ ./bin/schema-registry-start ./etc/schema-registry/schema-registry.properties &
 The AvroGenericSenderTest evaluates a generic approach, where the schema has to be provided with every request. Sending a message with an incompatible schema ends with a SerializationException and the invalid message never reaches the Kafka topic.
 
 # Avro specific approach
-In this approach a schema is provided in form of an Avro schema file, which is translated into a class file, which then can be used to create objects, either via constructors or builders.
+In this approach, a schema is provided in form of an Avro schema file, which is translated into a class file, which then can be used to create objects, either via constructors or builders.
 
 # Conclusions and miscellaneous notes
 Using the Schema Registry is in that sense transparent, that only the Avro serializers/deserializers have to be put into the Consumer's / Producer's config properties as well as the URL to the Schema Registry.
 
-There is an development overhead related to providing the schema, no matter if using the generic nor specific approach. A price to pay for "schema-aware" messages.
+There is development overhead related to providing the schema, no matter if using the generic nor specific approach. A price to pay for "schema-aware" messages.
 
-There should be a performance decrease, since each send request requires the schema to be verified for compatibility. It has been promised to keep it low due to caching on both, the serializer level and Schema Registry level.
+There should be a performance decrease since each send request requires the schema to be verified for compatibility. It has been promised to keep it low due to caching on both, the serializer level and Schema Registry level.
 
 By default schema events (register, update) are persisted in a Kafka topic called _schemas.
 
-Confluent ships a command line tool, that uses the Schema Registry  to inspect messages
+Confluent ships a command line tool that uses the Schema Registry to inspect messages
 
 ```$ ./bin/kafka-avro-console-consumer --from-beginning --zookeeper 127.0.0.1:2181 --topic <topic> --property schema.registry.url=http://127.0.0.1:8081```
 
@@ -61,8 +61,8 @@ The Schema Registry exposes a REST interface, which can be used to evaluate the 
 ```$ curl -X GET -i http://localhost:8081/subjects/<schema>/versions/latest```
 
 
-## Compatibilty Level
-To check the global compatibility level, which be default is **BACKWARD**, run:
+## Compatibility Level
+To check the global compatibility level, which by default is **BACKWARD**, run:
 
 ```$ curl -X GET -i http://localhost:8081/config/```
 


### PR DESCRIPTION
Replaces "nad" with "and"
Removes unnecessary commas
Adds missing commas
Trims whitespace
Adds missing 'i' in "Compatibilty
Replaces "be" with "by"